### PR TITLE
Limit the replacing of spec|app with app|spec to 1

### DIFF
--- a/resolver.py
+++ b/resolver.py
@@ -26,7 +26,7 @@ class Resolver:
 		if file.find('/spec/lib/') > -1:
 			file = re.sub(r'/spec/lib/', '/lib/', file)
 		else:
-			file = re.sub(r'/spec/', '/app/', file)
+			file = re.sub(r'/spec/', '/app/', file, 1)
 
 		return file
 
@@ -44,5 +44,5 @@ class Resolver:
 		if file.find('/lib/') > -1:
 			file = re.sub(r'/lib/', '/spec/lib/', file)
 		else:
-			file = re.sub(r'/app/', '/spec/', file)
+			file = re.sub(r'/app/', '/spec/', file, 1)
 		return file


### PR DESCRIPTION
If you had somewhere in your controllers/models another app folder it would still replace in the path.
Example:
controller: RAILS_ROOT/app/models/api/ **app** /device.rb
spec file would be: RAILS_ROOT/spec/models/api/ **spec** /device.rb
