### PR TITLE
Fix file paths on Windows

### DIFF
--- a/rails_go_to_spec.py
+++ b/rails_go_to_spec.py
@@ -8,6 +8,8 @@ class RailsGoToSpecCommand(sublime_plugin.WindowCommand):
 		win = self.window
 		view = win.active_view()
 		current_file = view.file_name()
+		if os.name == 'nt':
+			current_file = current_file.replace('\\', '/')
 		other_file = RailsGoToSpec.resolver.Resolver().run(current_file)
 		self.open(other_file)
 


### PR DESCRIPTION
Without this fix, plugin tries to open/create the spec file in the current directory since it works only with the `/` forward slashes in the path. However at Windows OS the standard is backward slashes `\`.

Windows is tolerant to the forward slashes. So I think we can just simply convert the slashes at the beginning.
